### PR TITLE
feat(coa): add paginated endpoint for fetching Chart of Accounts by book ID

### DIFF
--- a/src/common/enums/routes/routes.enum.ts
+++ b/src/common/enums/routes/routes.enum.ts
@@ -27,6 +27,7 @@ export enum Routes {
 
   // COA
   COA = 'accounts',
+  COA_PAGINATED = 'paginated',
 
   // Transaction
   TRANSACTION = 'transactions',

--- a/src/modules/coa/coa.controller.ts
+++ b/src/modules/coa/coa.controller.ts
@@ -16,6 +16,8 @@ import { CoaDetailResponse, CoaListResponse } from './coa.response';
 import { SuccessMessage } from 'src/common/enums/message/success-message.enum';
 import { CreateCoaDto, UpdateCoaDto } from './coa.dto';
 import { ApiCreatedResponse, ApiOkResponse } from '@nestjs/swagger';
+import { QueryPagination } from 'src/common/decorators/pagination.decorator';
+import { PaginationQuery } from 'src/types/api-query.type';
 
 @Controller(Routes.COA)
 export class CoaController {
@@ -51,6 +53,46 @@ export class CoaController {
     return {
       message: SuccessMessage.FETCHED,
       data: response,
+    };
+  }
+
+  @Get(Routes.COA_PAGINATED)
+  @ApiOkResponse({
+    description: 'Fetched',
+    type: CoaListResponse,
+    isArray: true,
+  })
+  async getAllCoaPaginatedByBookId(
+    @CurrentUser('sub') userId: string,
+    @Query('book_id') bookId: string,
+    @QueryPagination() pagination: PaginationQuery,
+  ): Promise<ResponseData<CoaListResponse[]>> {
+    const { data: coaData, extra_data } =
+      await this.coaService.getAllCoaPaginatedByBookId(
+        userId,
+        bookId,
+        pagination,
+      );
+
+    const response = coaData.map((coa) => ({
+      id: coa.id,
+      name: coa.name,
+      code: coa.code,
+      description: coa.description,
+      is_active: coa.isActive,
+      is_parent_group: coa.isParentGroup,
+      parent_id: coa.parentId,
+      level: coa.level,
+      currency: coa.currency,
+      position: coa.position,
+      type: coa.type,
+      category: coa.category,
+    }));
+
+    return {
+      message: SuccessMessage.FETCHED,
+      data: response,
+      extra_data,
     };
   }
 

--- a/src/modules/coa/services/coa.service.ts
+++ b/src/modules/coa/services/coa.service.ts
@@ -6,6 +6,8 @@ import { ExceptionCode } from 'src/common/enums/response-code/exception-code.enu
 import { ExceptionMessage } from 'src/common/enums/message/exception-message.enum';
 import throwException from 'src/shared/exception/throw.exception';
 import { AccountTypeMapper } from 'src/common/mappers/account-type.mapper';
+import { PaginationQuery } from 'src/types/api-query.type';
+import { paginateData } from 'src/shared/utils/pagination.util';
 
 @Injectable()
 export class CoaService {
@@ -128,6 +130,55 @@ export class CoaService {
         parentId: true,
       },
     });
+  }
+
+  /**
+   * Retrieves paginated Chart of Accounts for a specific book
+   *
+   * @param userId - The ID of the user requesting the accounts
+   * @param bookId - The ID of the book containing the accounts
+   * @param pagination - Pagination query parameters
+   * @returns Array of accounts with selected fields
+   * @throws ForbiddenException if user doesn't have access to the book
+   */
+  async getAllCoaPaginatedByBookId(
+    userId: string,
+    bookId: string,
+    pagination: PaginationQuery,
+  ) {
+    await this.bookService.validateBookAccess(userId, bookId);
+
+    return paginateData(
+      Promise.all([
+        this.prisma.account.findMany({
+          skip: pagination.skip,
+          take: pagination.take,
+          where: {
+            bookId,
+          },
+          select: {
+            id: true,
+            name: true,
+            code: true,
+            description: true,
+            isActive: true,
+            isParentGroup: true,
+            level: true,
+            currency: true,
+            position: true,
+            type: true,
+            category: true,
+            parentId: true,
+          },
+        }),
+        this.prisma.account.count({
+          where: {
+            bookId,
+          },
+        }),
+      ]),
+      pagination,
+    );
   }
 
   /**


### PR DESCRIPTION


- Introduced COA_PAGINATED route for retrieving paginated Chart of Accounts.
- Implemented getAllCoaPaginatedByBookId method in CoaService to handle pagination logic.
- Updated CoaController to include new endpoint with Swagger documentation for API response.